### PR TITLE
5.18 fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,16 @@
 use lib qw(inc);
 use Devel::CheckLib;
+
+# Prompt the user here for any paths and other configuration
+
+check_lib_or_exit(
+    # fill in what you prompted the user for here
+    lib => [qw()]
+);
+
+
+use lib qw(inc);
+use Devel::CheckLib;
 use ExtUtils::MakeMaker;
 use Config;
 use strict;

--- a/lib/Crypt/GCrypt/MPI.pm
+++ b/lib/Crypt/GCrypt/MPI.pm
@@ -21,6 +21,8 @@ use Crypt::GCrypt;
 1;
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 Crypt::GCrypt::MPI - Perl interface to multi-precision integers from the GNU Cryptographic library


### PR DESCRIPTION
Module doesn't compile on perl 5.18 because of outdated Devel::CheckLib. Also it fails tests because POD encoding is not specified. These two commits fix the problems.
