### PR TITLE
Include gcrypt.h when using gcry_check_version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,6 +41,7 @@ if (not $gcrypt_libpath and $] >= 5.006001) {
 # SHA-512)
 check_lib_or_exit(
     function => 'if (gcry_check_version("1.3.0")) return 0; else return 1;',
+    header => 'gcrypt.h',
     lib => [qw(gcrypt)],
     libpath => $gcrypt_libpath
 );


### PR DESCRIPTION
Failure to include the required header results in an implicit declaration of function, which is an error in the version of clang included with Xcode 12 and later on macOS, and results in gcrypt not being found and the module failing to build.

This was originally [reported to MacPorts](https://trac.macports.org/ticket/61601).